### PR TITLE
feat: :sparkles: add functionality for the server be able to reuse an address

### DIFF
--- a/includes/ServerListen.hpp
+++ b/includes/ServerListen.hpp
@@ -24,6 +24,7 @@ class ServerListen : public EpollHandler {
         void setServerAddr(int socketDomain);
         void createServerSocket(int socketDomain, int socketType);
         void bindServerSocket(void);
+        void allowAddrReuse(void);
         void updateToNonBlocking(void);
         void listenServerSocket(void);
         void initServerSocket(int socketDomain, int socketType);
@@ -44,6 +45,11 @@ class ServerListen : public EpollHandler {
         };
 
         class CannotSetServerToListen : public std::exception {
+            public:
+                virtual const char *what() const throw();
+        };
+
+        class CannotAllowAddrReuse : public std::exception {
             public:
                 virtual const char *what() const throw();
         };

--- a/source/ServerListen.cpp
+++ b/source/ServerListen.cpp
@@ -108,9 +108,18 @@ void ServerListen::listenServerSocket(void) {
     }
 }
 
+void ServerListen::allowAddrReuse(void) {
+    int option = 1;
+
+    if (setsockopt(this->getSocketFd(), SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option)) == -1) {
+        throw(ServerListen::CannotAllowAddrReuse());
+    }
+}
+
 void ServerListen::initServerSocket(int socketDomain, int socketType) {
     this->createServerSocket(socketDomain, socketType);
     this->setServerAddr(socketDomain);
+    this->allowAddrReuse();
     this->bindServerSocket();
     this->updateToNonBlocking();
     this->listenServerSocket();
@@ -130,4 +139,8 @@ const char * ServerListen::CannotUpdateServerToNonBlocking::what() const throw()
 
 const char * ServerListen::CannotSetServerToListen::what() const throw() {
     return ("Error: error in setting the server to listen with listen().");
+}
+
+const char * ServerListen::CannotAllowAddrReuse::what() const throw() {
+    return ("Error: error in allowing address reuse with setsockopt().");
 }


### PR DESCRIPTION
Nova feature que possibilita reutilizarmos um address que já foi usado anteriormente. Usamos a Syscall setsockopt().

Caso queiram testar, comentem a função, executem o servidor, encerrem com CTRL+C e, sem dar make re, inicializem o servidor novamente com a mesma configuração usada anteriormente. Nesse caso dela comentada, deve dar uma exception no no bind(). Caso contrário, deve funcionar normalmente!

Façam isso com a função comentada e descomentada.